### PR TITLE
Add BrowserWindow setBackgroundColor shim

### DIFF
--- a/src/ElectronNET.API/BrowserWindow.cs
+++ b/src/ElectronNET.API/BrowserWindow.cs
@@ -2233,6 +2233,17 @@ public class BrowserWindow
     }
 
     /// <summary>
+    /// window's background color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format.
+    /// Alpha in #AARRGGBB format is supported if transparent is set to true.
+    /// Default is #FFF (white)    
+    /// </summary>
+    /// <param name="backgroundColor">The color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format</param>
+    public void SetBackgroundColor(string backgroundColor) 
+    {
+        BridgeConnector.Socket.Emit("browserWindowSetBackgroundColor", Id, backgroundColor);
+    }
+
+    /// <summary>
     /// Render and control web pages.
     /// </summary>
     public WebContents WebContents { get; internal set; }

--- a/src/ElectronNET.API/ElectronNET.API.csproj
+++ b/src/ElectronNET.API/ElectronNET.API.csproj
@@ -16,7 +16,7 @@ This package contains the API to access the "native" electron API.</Description>
     <PackageTags>electron aspnetcore</PackageTags>
     <PackageReleaseNotes>Changelog: https://github.com/ElectronNET/Electron.NET/blob/main/Changelog.md</PackageReleaseNotes>
     <PackageIcon>PackageIcon.png</PackageIcon>
-    <Version>99.0.7.0</Version>
+    <Version>99.0.8.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ElectronNET.Host/api/browserWindows.js
+++ b/src/ElectronNET.Host/api/browserWindows.js
@@ -580,6 +580,9 @@ module.exports = (socket, app) => {
     socket.on('browserWindowSetVibrancy', (id, type) => {
         getWindowById(id).setVibrancy(type);
     });
+    socket.on('browserWindowSetBackgroundColor', (id, backgroundColor) => {
+        getWindowById(id).setBackgroundColor(backgroundColor);
+    });
     socket.on('browserWindow-setBrowserView', (id, browserViewId) => {
         getWindowById(id).setBrowserView((0, browserView_1.browserViewMediateService)(browserViewId));
     });

--- a/src/ElectronNET.Host/api/browserWindows.ts
+++ b/src/ElectronNET.Host/api/browserWindows.ts
@@ -752,6 +752,10 @@ export = (socket: Socket, app: Electron.App) => {
         getWindowById(id).setVibrancy(type);
     });
 
+    socket.on('browserWindowSetBackgroundColor', (id, backgroundColor) => {
+        getWindowById(id).setBackgroundColor(backgroundColor);
+    });
+
     socket.on('browserWindow-setBrowserView', (id, browserViewId) => {
         getWindowById(id).setBrowserView(browserViewMediateService(browserViewId));
     });


### PR DESCRIPTION
Add SetBackgroundColor method to the BrowserWindow type for use toggling background opacity for use with ReHUD VR mode.